### PR TITLE
Prevent Page Link being reloaded

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import cs from 'classnames'
@@ -27,6 +26,7 @@ import { Page404 } from './Page404'
 import { PageAside } from './PageAside'
 import { PageHead } from './PageHead'
 import styles from './styles.module.css'
+import PageLink from "@/components/PageLink";
 
 // -----------------------------------------------------------------------------
 // dynamic imports for optional components
@@ -154,7 +154,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
   const components = React.useMemo(
     () => ({
       nextImage: Image,
-      nextLink: Link,
+      PageLink,
       Code,
       Collection,
       Equation,

--- a/components/PageLink.tsx
+++ b/components/PageLink.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react'
+import Link from 'next/link'
+
+type NextLinkProps = {
+  href: string
+  className?: string
+  children: React.ReactNode
+}
+
+const PageLink: FC<NextLinkProps> = ({ href, className, children }) => {
+  return (
+    <Link href={href} passHref>
+      <a className={className}>
+        {children}
+      </a>
+    </Link>
+  )
+}
+
+export default PageLink


### PR DESCRIPTION
#### Description

This is to prevent reloading the Notion page links.

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
